### PR TITLE
Revert "feat: add a notice to cancel the workflow"

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -8,9 +8,6 @@ runs:
   using: composite
   steps:
     - shell: bash
-      run: |
-        echo "::notice title=How to cancel the workflow::/cancel $GITHUB_RUN_ID"
-    - shell: bash
       if: fromJSON(inputs.data).event.pull_request.html_url
       run: |
         cat << EOS >> "$GITHUB_STEP_SUMMARY"
@@ -21,6 +18,23 @@ runs:
         
         Please post a comment to the [Pull Request]($PR_URL).
 
+        Rerun the workflow.
+
+        $CODE_BLOCK
+        /rerun-workflow $GITHUB_RUN_ID
+        $CODE_BLOCK
+
+        Rerun failed jobs.
+
+        $CODE_BLOCK
+        /rerun-failed-job $GITHUB_RUN_ID
+        $CODE_BLOCK
+
+        Cancel the workflow.
+
+        $CODE_BLOCK
+        /cancel $GITHUB_RUN_ID
+        $CODE_BLOCK
         EOS
       env:
         PR_URL: ${{fromJSON(inputs.data).event.pull_request.html_url}}
@@ -33,13 +47,6 @@ runs:
         ## How to rerun or cancel the Workflow and jobs
         
         Please post a comment to any this repository's issue or pull request.
-
-        EOS
-      env:
-        CODE_BLOCK: "```"
-    - shell: bash
-      run: |
-        cat << EOS >> "$GITHUB_STEP_SUMMARY"
 
         Rerun the workflow.
 


### PR DESCRIPTION
Reverts gha-trigger/step-summary-action#6

Unfortunately, the message of `notice` isn't shown until the job has been finished.